### PR TITLE
api plateform configuration was not valid

### DIFF
--- a/.recipe/config/packages/monofony_api.yaml
+++ b/.recipe/config/packages/monofony_api.yaml
@@ -2,10 +2,12 @@ api_platform:
     version: !php/const App\Kernel::VERSION
     mapping:
         paths: ['%kernel.project_dir%/config/api_platform/resources/']
-    api_keys:
-        apiKey:
-            name: Authorization
-            type: header
+    swagger:
+        versions: [3]
+        api_keys:
+            apiKey:
+                name: Authorization
+                type: header
 
 framework:
     serializer:


### PR DESCRIPTION
The api plateform configuration is wrong.
`api_keys` must be under `swagger`